### PR TITLE
use quicklisp-home instead of hardcoded path

### DIFF
--- a/maxima-quicklisp.lisp
+++ b/maxima-quicklisp.lisp
@@ -8,11 +8,12 @@
                                       "/" user-string
                                       "/" project-string
                                       "/tarball/" ref-string))
+     (ql-home (format nil "~a" ql:*quicklisp-home*))
      (tar.gz-bytes (drakma:http-request url-string :connection-timeout nil))
-     (tar-filename (concatenate 'string "/home/robert/quicklisp/dists/quicklisp/archives/" project-string "-" ref-string))
+     (tar-filename (concatenate 'string ql-home "dists/quicklisp/archives/" project-string "-" ref-string))
      (tar.gz-filename (concatenate 'string tar-filename ".gz")))
     (with-open-file (f tar.gz-filename :direction :output :if-exists :supersede :element-type '(unsigned-byte 8))
       (write-sequence tar.gz-bytes f))
     (ql-gunzipper:gunzip tar.gz-filename tar-filename)
-    (ql-minitar:unpack-tarball tar-filename :directory "/home/robert/quicklisp/local-projects/")
+    (ql-minitar:unpack-tarball tar-filename :directory (concatenate 'string ql-home "local-projects/"))
     (delete-file tar-filename)))


### PR DESCRIPTION
Hello Robert,

Thanks for this!

Since not everybody has access to your homefolder, I made a small change so that tar files are stored and untarred in ql:_quicklisp-home_
I'm not sure this will work on windows (and I assume we'll want to make this work on windows too), I'll be trying in the near future, as soon as I have access to a windows machine.

It took me a while to find out I had to add the maxima-file directory to asdf:_central-registry_. even though it is mentioned (implicitly) in the readme. Maybe it's an idea to make it stand out a bit more.

  serge
