### PR TITLE
update maxima paths after loading the package

### DIFF
--- a/maxima-asdf.lisp
+++ b/maxima-asdf.lisp
@@ -12,5 +12,24 @@
 (defun $asdf_compile (name)
   (asdf:compile-system name))
 
+(defmacro append-to-path (path-variable path item)
+  `(let ((to-be-added (concatenate 'string ,path ,item)))
+     (unless (member to-be-added (rest ,path-variable) :test #'string=)
+       (setq ,path-variable (append ,path-variable (list to-be-added))))))
+
+(defun append-to-maxima-paths (p)
+  (declare (special $file_search_demo $file_search_lisp $file_search_maxima $file_search_tests $file_search_usage))
+  (append-to-path $file_search_demo p "$$$.{dem,demo}")
+  (append-to-path $file_search_lisp p "$$$.lisp")
+  (append-to-path $file_search_maxima p "$$$.mac")
+  (append-to-path $file_search_tests p "$$$.mac")
+  (append-to-path $file_search_usage p "$$$.{usg,txt}"))
+
 (defun $asdf_load_source (name)
-  (asdf:oos 'asdf:load-source-op name))
+  (prog1
+      (asdf:oos 'asdf:load-source-op name)
+    (let ((source-topdir (format nil "~a" (ql:where-is-system name))))
+      (append-to-maxima-paths source-topdir))))
+
+
+

--- a/maxima-quicklisp.lisp
+++ b/maxima-quicklisp.lisp
@@ -37,14 +37,3 @@
 	     (delete-file tar-filename)
 	     (list '(mlist) tar.gz-filename package-toplevel-path))))
 	(merror (format nil "~a: ~a" http-status (seventh request-results))))))
-
-(defmacro append-to-path (path-variable path item)
-  `(setq ,path-variable (append ,path-variable (list (concatenate 'string ,path ,item)))))
-
-(defun append-to-maxima-paths (p)
-  (declare (special $file_search_demo $file_search_lisp $file_search_maxima $file_search_tests $file_search_usage))
-  (append-to-path $file_search_demo p "$$$.{dem,demo}")
-  (append-to-path $file_search_lisp p "$$$.lisp")
-  (append-to-path $file_search_maxima p "$$$.mac")
-  (append-to-path $file_search_tests p "$$$.mac")
-  (append-to-path $file_search_usage p "$$$.{usg,txt}"))


### PR DESCRIPTION
Quicklisp can tell us where a project is located with (ql:where-is-system <system>).
This wouldn't work for maxima packages which have files which are not in the toplevel directory.
I'm also not sure for the (format nil "~a" <pathname>) trick to convert the pathname to a string (especially concerning portability to other platforms).
