### PR TITLE
Add asd and loading instructions for maxima-asdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Quicklisp, which makes them available to ASDF.
 
 ## What's here
 
-- maxima-file/
+- maxima-file.lisp
 
   Definition of the :maxima-file component for ASDF.
 
@@ -18,27 +18,28 @@ Quicklisp, which makes them available to ASDF.
 
 - maxima\-quicklisp.lisp
 
-  Glue code for downloading and installing packages 
+  Glue code for downloading and installing packages
   from Github into quicklisp/local-projects/.
 
 ## How to use it
 
-Here is an example using the clifford package by Dimiter Prodanov.
-I forked clifford on Github and added a clifford.asd file.
+- Copy maxima-asdf/ to quicklisp/local-projects/ or do the following in
+  quicklisp/local-projects/
 
-Note that the clifford package contains a couple of sizeable documents,
-so it might take a few moments to download.
+      git clone https://github.com/robert-dodier/maxima-asdf.git
 
-- Copy maxima-file/ to quicklisp/local-projects/.
+- Load `maxima-asdf` by executing `:lisp (ql:quicklisp :maxima-asdf)` in your
+  Maxima session or by putting `(ql:quicklisp :maxima-asdf)` in
+  `maxima-init.lisp`. Please note that Quicklisp must be loaded in every Maxima
+  session.
 
-- Launch Maxima. The rest of the steps are carried out in the Maxima session.
+- Use `install_github` to install projects and `asdf_load_source` to load
+  packages. A sample session is included below using the clifford package by
+  Dimiter Prodanov. In order to make clifford loadable via `asdf_load_source`, I
+  forked clifford on Github and added a clifford.asd file. Note that the
+  clifford package contains a couple of sizeable documents, so it might take a
+  few moments to download.
 
-- `load ("maxima-asdf.lisp");`
-
-- `load ("maxima-quicklisp.lisp")`;
-
-- `install_github ("robert-dodier", "clifford", "master");`
-
-- `asdf_load_source ("clifford");`
-
-- `demo (clifford);`
+      install_github ("robert-dodier", "clifford", "master");
+      asdf_load_source ("clifford");
+      demo (clifford);

--- a/maxima-asdf.asd
+++ b/maxima-asdf.asd
@@ -1,0 +1,10 @@
+(defsystem maxima-asdf
+  :name "maxima-asdf"
+  :defsystem-depends-on ("drakma")
+  :maintainer "Robert Dodier"
+  :author "Robert Dodier"
+  :licence "GPL"
+  :description "Define :maxima-asdf for ASDF"
+  :long-description "Define :maxima-asdf ASDF."
+  :components ((:file "maxima-asdf")
+               (:file "maxima-quicklisp")))

--- a/maxima-quicklisp.lisp
+++ b/maxima-quicklisp.lisp
@@ -2,9 +2,7 @@
 ;; copyright 2016 by Robert Dodier
 ;; I release this work under terms of the GNU GPL version 2
 
-;; I'd rather do (require 'drakma) here ... oh well.
-(if (not (gethash "drakma" asdf::*defined-systems*))
-  (ql:quickload :drakma))
+(require 'drakma)
 
 ;; install_github -- download a tarball from Github and unpack it into quicklisp/local-projects/.
 ;; Append the top-level project directory to various Maxima search paths.


### PR DESCRIPTION
This PR adds an ASD file for maxima-asdf. This makes it possible to load the whole package with `(ql:quickload :maxima-asdf)` if the entire source directory is placed into `quicklisp/local-projects`. If `(ql:quickload :maxima-asdf)` is placed into `maxima-init.lisp` then the following is possible.

```
install_github("maxima-project-on-github", "maxima-packages", "master");
asdf_load_source ("texify");
texify(x^2+x+1);
```
